### PR TITLE
Add 'Pawn Structure Detected' label in output

### DIFF
--- a/PawnStructureFinder.py
+++ b/PawnStructureFinder.py
@@ -59,7 +59,7 @@ index e6d8d4f7d1fb24de9ba1adb69b888759fe8cfe29..b44b744ed492bdae3e3b7fd00201e1d5
 def _format_detection(game_idx, title, structure, fullmove, moved_side, san):
     """Devuelve la línea de resultado con el formato requerido."""
     return (
-        f"Partida #{game_idx} | {title} - {structure} - "
+        f"Partida #{game_idx} | {title} - Pawn Structure Detected: {structure} - "
         f"Detectada en jugada {fullmove} tras {moved_side} jugar {san}"
     )
 


### PR DESCRIPTION
## Summary
- Include `Pawn Structure Detected:` prefix in formatted detection lines

## Testing
- `python -m py_compile PawnStructureFinder.py` *(fails: SyntaxError due to non-Python content at top of file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa08ad9c832db6cd88f3e8c3cb75